### PR TITLE
feat: import default adapter from parse5 entrypoint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@parse5/tools",
-  "version": "0.1.0",
+  "version": "0.1.1-nodenext.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@parse5/tools",
-      "version": "0.1.0",
+      "version": "0.1.1-nodenext.0",
       "license": "MIT",
       "dependencies": {
         "parse5": "^7.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1639,9 +1639,9 @@
       }
     },
     "node_modules/parse5": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.0.tgz",
-      "integrity": "sha512-jo4pIv8LVI1IO2QxismoCv/+qZC6V3VSxOHqEQIpm5kDSzJNLNIVUwdStdUnezexjwdZXgYkxP5nanlZgfcCHg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "dependencies": {
         "entities": "^4.4.0"
       },
@@ -3308,9 +3308,9 @@
       }
     },
     "parse5": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.0.tgz",
-      "integrity": "sha512-jo4pIv8LVI1IO2QxismoCv/+qZC6V3VSxOHqEQIpm5kDSzJNLNIVUwdStdUnezexjwdZXgYkxP5nanlZgfcCHg==",
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.1.2.tgz",
+      "integrity": "sha512-Czj1WaSVpaoj0wbhMzLmWD69anp2WH7FXMB9n1Sy8/ZFF9jolSQVMu1Ij5WIyGmcBmhk7EOndpO4mIpihVqAXw==",
       "requires": {
         "entities": "^4.4.0"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@parse5/tools",
-  "version": "0.1.0",
+  "version": "0.1.1-nodenext.0",
   "description": "A small set of utilities for dealing with parse5 syntax trees",
   "main": "lib/main.js",
   "files": [

--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -1,4 +1,4 @@
-import type {Element} from 'parse5/dist/tree-adapters/default.js';
+import type {Element} from './nodeTypes.js';
 
 /**
  * Sets the given attribute on the specified node

--- a/src/creation.ts
+++ b/src/creation.ts
@@ -6,7 +6,7 @@ import type {
   Template,
   DocumentFragment,
   Document
-} from 'parse5/dist/tree-adapters/default.js';
+} from './nodeTypes.js';
 
 const namespaceMap: Record<string, html.NS> = {
   HTML: html.NS.HTML,

--- a/src/nodeTypes.ts
+++ b/src/nodeTypes.ts
@@ -1,0 +1,12 @@
+import type {DefaultTreeAdapterMap} from 'parse5';
+
+export type ChildNode = DefaultTreeAdapterMap['childNode'];
+export type CommentNode = DefaultTreeAdapterMap['commentNode'];
+export type Document = DefaultTreeAdapterMap['document'];
+export type DocumentFragment = DefaultTreeAdapterMap['documentFragment'];
+export type DocumentType = DefaultTreeAdapterMap['documentType'];
+export type Element = DefaultTreeAdapterMap['element'];
+export type Node = DefaultTreeAdapterMap['node'];
+export type ParentNode = DefaultTreeAdapterMap['parentNode'];
+export type Template = DefaultTreeAdapterMap['template'];
+export type TextNode = DefaultTreeAdapterMap['textNode'];

--- a/src/test/attributes_test.ts
+++ b/src/test/attributes_test.ts
@@ -2,7 +2,7 @@ import {strict as assert} from 'node:assert';
 import test from 'node:test';
 import * as main from '../main.js';
 import {html} from 'parse5';
-import type {Element} from 'parse5/dist/tree-adapters/default.js';
+import type {Element} from '../nodeTypes.js';
 
 test('setAttribute', async (t) => {
   await t.test('adds attribute to elemet attrs', () => {

--- a/src/test/text_test.ts
+++ b/src/test/text_test.ts
@@ -8,7 +8,7 @@ import type {
   TextNode,
   DocumentType,
   DocumentFragment
-} from 'parse5/dist/tree-adapters/default.js';
+} from '../nodeTypes.js';
 
 test('getTextContent', async (t) => {
   await t.test('returns data of comment', () => {

--- a/src/test/traversal_test.ts
+++ b/src/test/traversal_test.ts
@@ -7,7 +7,7 @@ import type {
   Element,
   TextNode,
   DocumentFragment
-} from 'parse5/dist/tree-adapters/default.js';
+} from '../nodeTypes.js';
 
 test('query', async (t) => {
   await t.test('retrieves first matching child', () => {

--- a/src/test/traverse_test.ts
+++ b/src/test/traverse_test.ts
@@ -2,11 +2,7 @@ import {strict as assert} from 'node:assert';
 import test from 'node:test';
 import * as main from '../main.js';
 import {html} from 'parse5';
-import type {
-  Node,
-  TextNode,
-  DocumentFragment
-} from 'parse5/dist/tree-adapters/default.js';
+import type {Node, TextNode, DocumentFragment} from '../nodeTypes.js';
 
 test('traverse', async (t) => {
   await t.test('calls node callback when encountered', () => {

--- a/src/test/treeMutation_test.ts
+++ b/src/test/treeMutation_test.ts
@@ -2,11 +2,7 @@ import {strict as assert} from 'node:assert';
 import test from 'node:test';
 import * as main from '../main.js';
 import {defaultTreeAdapter, html} from 'parse5';
-import type {
-  Document,
-  TextNode,
-  DocumentFragment
-} from 'parse5/dist/tree-adapters/default.js';
+import type {Document, TextNode, DocumentFragment} from '../nodeTypes.js';
 
 test('removeNode', async (t) => {
   await t.test('does nothing if not a child', () => {

--- a/src/test/typeGuards_test.ts
+++ b/src/test/typeGuards_test.ts
@@ -10,7 +10,7 @@ import type {
   Template,
   DocumentType,
   DocumentFragment
-} from 'parse5/dist/tree-adapters/default.js';
+} from '../nodeTypes.js';
 
 test('isElementNode', async (t) => {
   await t.test('delegates to default adapter', () => {

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,4 +1,4 @@
-import type {Node} from 'parse5/dist/tree-adapters/default.js';
+import type {Node} from './nodeTypes.js';
 import {isCommentNode, isTextNode, isParentNode} from './typeGuards.js';
 import {appendChild} from './treeMutation.js';
 import {createTextNode} from './creation.js';

--- a/src/traversal.ts
+++ b/src/traversal.ts
@@ -1,4 +1,4 @@
-import type {Node} from 'parse5/dist/tree-adapters/default.js';
+import type {Node} from './nodeTypes.js';
 import {isParentNode, isChildNode} from './typeGuards.js';
 
 /**

--- a/src/traverse.ts
+++ b/src/traverse.ts
@@ -8,7 +8,7 @@ import type {
   Document,
   DocumentType,
   Node
-} from 'parse5/dist/tree-adapters/default.js';
+} from './nodeTypes.js';
 import {
   isParentNode,
   isDocument,

--- a/src/treeMutation.ts
+++ b/src/treeMutation.ts
@@ -1,6 +1,9 @@
 import {defaultTreeAdapter} from 'parse5';
+import type {DefaultTreeAdapterMap, TreeAdapter} from 'parse5';
 import {isChildNode, isParentNode} from './typeGuards.js';
-import type {ChildNode, Node} from 'parse5/dist/tree-adapters/default.js';
+import type {ChildNode, Node} from './nodeTypes.js';
+
+type DefaultTreeAdapterLike = TreeAdapter<DefaultTreeAdapterMap>;
 
 /**
  * Attempts to remove the given node from the AST
@@ -15,7 +18,8 @@ export function removeNode(node: Node): void {
   defaultTreeAdapter.detachNode(node);
 }
 
-export const appendChild = defaultTreeAdapter.appendChild;
+export const appendChild: DefaultTreeAdapterLike['appendChild'] =
+  defaultTreeAdapter.appendChild;
 
 /**
  * Performs a splice on the children of the given node

--- a/src/typeGuards.ts
+++ b/src/typeGuards.ts
@@ -1,4 +1,5 @@
 import {defaultTreeAdapter} from 'parse5';
+import type {DefaultTreeAdapterMap, TreeAdapter} from 'parse5';
 import type {
   ParentNode,
   ChildNode,
@@ -6,7 +7,9 @@ import type {
   DocumentFragment,
   Document,
   Node
-} from 'parse5/dist/tree-adapters/default.js';
+} from './nodeTypes.js';
+
+type DefaultTreeAdapterLike = TreeAdapter<DefaultTreeAdapterMap>;
 
 /**
  * Determines if a given node is a document or not
@@ -35,13 +38,17 @@ export function isTemplateNode(node: Node): node is Template {
   return node.nodeName === 'template';
 }
 
-export const isElementNode = defaultTreeAdapter.isElementNode;
+export const isElementNode: DefaultTreeAdapterLike['isElementNode'] =
+  defaultTreeAdapter.isElementNode;
 
-export const isCommentNode = defaultTreeAdapter.isCommentNode;
+export const isCommentNode: DefaultTreeAdapterLike['isCommentNode'] =
+  defaultTreeAdapter.isCommentNode;
 
-export const isDocumentTypeNode = defaultTreeAdapter.isDocumentTypeNode;
+export const isDocumentTypeNode: DefaultTreeAdapterLike['isDocumentTypeNode'] =
+  defaultTreeAdapter.isDocumentTypeNode;
 
-export const isTextNode = defaultTreeAdapter.isTextNode;
+export const isTextNode: DefaultTreeAdapterLike['isTextNode'] =
+  defaultTreeAdapter.isTextNode;
 
 /**
  * Determines if a given node is a parent or not


### PR DESCRIPTION
Since parse5 doesn't specify the tree-adapters directory in its `package.json`, we can't import it without breaking `nodeNext` builds.

To resolve this, we now pull it in from the root of parse5 and construct our own alias internally to simplify the code.

I also upgraded parse5 since the latest version allows for string node types rather than enums.

Fixes #16 

cc @augustjk