### PR TITLE
Allow modification of existing attributes and text content.

### DIFF
--- a/src/attributes.ts
+++ b/src/attributes.ts
@@ -8,6 +8,8 @@ import type {Element} from './nodeTypes.js';
  * @return {void}
  */
 export function setAttribute(node: Element, name: string, value: string): void {
+  removeAttribute(node, name);
+
   node.attrs.push({
     name,
     value

--- a/src/test/attributes_test.ts
+++ b/src/test/attributes_test.ts
@@ -19,6 +19,22 @@ test('setAttribute', async (t) => {
 
     assert.deepStrictEqual(node.attrs, [{name: 'ping-pong', value: 'boing'}]);
   });
+
+  await t.test('modifies existing attribute on element', () => {
+    const node: Element = {
+      nodeName: 'div',
+      parentNode: null,
+      tagName: 'div',
+      attrs: [{name: 'foo', value: 'bar'}],
+      namespaceURI: html.NS.HTML,
+      childNodes: []
+    };
+
+    main.setAttribute(node, 'foo', 'baz');
+
+    assert.strictEqual(node.attrs.length, 1);
+    assert.deepStrictEqual(node.attrs, [{name: 'foo', value: 'baz'}]);
+  });
 });
 
 test('getAttribute', async (t) => {

--- a/src/test/text_test.ts
+++ b/src/test/text_test.ts
@@ -164,6 +164,28 @@ test('setTextContent', async (t) => {
     });
   });
 
+  await t.test('sets text node for parent nodes', () => {
+    const node: DocumentFragment = {
+      nodeName: '#document-fragment',
+      childNodes: []
+    };
+
+    node.childNodes.push({
+      nodeName: '#text',
+      value: 'old text',
+      parentNode: node
+    });
+
+    main.setTextContent(node, 'new text');
+
+    assert.strictEqual(node.childNodes.length, 1);
+    assert.deepStrictEqual(node.childNodes[0], {
+      nodeName: '#text',
+      value: 'new text',
+      parentNode: node
+    });
+  });
+
   await t.test('ignores document type nodes', () => {
     const node: DocumentType = {
       nodeName: '#documentType',

--- a/src/test/text_test.ts
+++ b/src/test/text_test.ts
@@ -35,16 +35,28 @@ test('getTextContent', async (t) => {
     assert.strictEqual(result, 'some text');
   });
 
+  await t.test('returns value of comment node', () => {
+    const node: CommentNode = {
+      nodeName: '#comment',
+      parentNode: null,
+      data: 'some comment'
+    };
+
+    const result = main.getTextContent(node);
+
+    assert.strictEqual(result, 'some comment');
+  });
+
   await t.test('concats all text-like children', () => {
     const child1: TextNode = {
       nodeName: '#text',
       parentNode: null,
-      value: 'text node'
+      value: 'text node 1'
     };
-    const child2: CommentNode = {
-      nodeName: '#comment',
+    const child2: TextNode = {
+      nodeName: '#text',
       parentNode: null,
-      data: 'comment node'
+      value: 'text node 2'
     };
     const node: DocumentFragment = {
       nodeName: '#document-fragment',
@@ -53,7 +65,7 @@ test('getTextContent', async (t) => {
 
     const result = main.getTextContent(node);
 
-    assert.strictEqual(result, 'text nodecomment node');
+    assert.strictEqual(result, 'text node 1text node 2');
   });
 
   await t.test('ignores non-text children', () => {

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,6 +1,5 @@
-import type {Node} from './nodeTypes.js';
+import type {Node, ParentNode} from './nodeTypes.js';
 import {isCommentNode, isTextNode, isParentNode} from './typeGuards.js';
-import {appendChild, removeNode} from './treeMutation.js';
 import {createTextNode} from './creation.js';
 import {queryAll} from './traversal.js';
 
@@ -21,10 +20,7 @@ export function getTextContent(node: Node): string {
 
   let content = '';
 
-  const children = queryAll(
-    node,
-    (node) => isTextNode(node) || isCommentNode(node)
-  );
+  const children = queryAll(node, (node) => isTextNode(node));
 
   for (const child of children) {
     content += getTextContent(child);
@@ -45,16 +41,8 @@ export function setTextContent(node: Node, text: string): void {
   } else if (isTextNode(node)) {
     node.value = text;
   } else if (isParentNode(node)) {
-    const children = queryAll(
-      node,
-      (node) => isTextNode(node) || isCommentNode(node)
-    );
+    var parent: ParentNode = node;
 
-    for (const child of children) {
-      removeNode(child);
-    }
-
-    const textNode = createTextNode(text);
-    appendChild(node, textNode);
+    parent.childNodes = [createTextNode(text)];
   }
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,7 +1,8 @@
-import type {Node, ParentNode} from './nodeTypes.js';
+import type {Node} from './nodeTypes.js';
 import {isCommentNode, isTextNode, isParentNode} from './typeGuards.js';
 import {createTextNode} from './creation.js';
 import {queryAll} from './traversal.js';
+import {appendChild} from './treeMutation.js';
 
 /**
  * Computes the text content of a given node using a similar
@@ -41,8 +42,7 @@ export function setTextContent(node: Node, text: string): void {
   } else if (isTextNode(node)) {
     node.value = text;
   } else if (isParentNode(node)) {
-    var parent: ParentNode = node;
-
-    parent.childNodes = [createTextNode(text)];
+    node.childNodes = [];
+    appendChild(node, createTextNode(text));
   }
 }

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,6 +1,6 @@
 import type {Node} from './nodeTypes.js';
 import {isCommentNode, isTextNode, isParentNode} from './typeGuards.js';
-import {appendChild} from './treeMutation.js';
+import {appendChild, removeNode} from './treeMutation.js';
 import {createTextNode} from './creation.js';
 import {queryAll} from './traversal.js';
 
@@ -45,6 +45,15 @@ export function setTextContent(node: Node, text: string): void {
   } else if (isTextNode(node)) {
     node.value = text;
   } else if (isParentNode(node)) {
+    const children = queryAll(
+      node,
+      (node) => isTextNode(node) || isCommentNode(node)
+    );
+
+    for (const child of children) {
+      removeNode(child);
+    }
+
     const textNode = createTextNode(text);
     appendChild(node, textNode);
   }


### PR DESCRIPTION
Ignoring my previous issue, I ended up stumbling across an issue when modifying the value of attributes that were already attached to an element, as well as modifying existing text content.

The previous behavior for `setAttribute` was to simply append a new attribute to the `attrs` array, while this does work for new elements, it causes issues when attempting to override existing attributes. When parse5 serializes the AST, it only recognizes the first attribute of a type, and ignores any others with the same name. This behavior is un-intuitive as calling `setAttribute` in some situations may have no effect on the serialized content.

This issue is easily fixed by simply removing any old attributes with the given name.

I also stumbled across a very similar issue with `setTextContent` when modifying the text content of some elements. This issue was also caused by appending new text nodes without removing any previous content beforehand. While the old behavior does act similar to the `document.write()` function, the name `setTextContent` doesn't match the functionality. If this behavior is intended, I would recommend renaming `setTextContent` to `appendTextContent` and creating a new function for `setTextContent` which behaves intuitively.

This issue was also easily fixed by removing any text nodes from a parent element before appending the new content. 